### PR TITLE
Specify tensorflow-gpu version

### DIFF
--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -69,7 +69,7 @@ RUN pip --no-cache-dir install \
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 
 #RUN pip --no-cache-dir install tf-nightly$(test "$base_image" != "$cpu_base_image" && echo "-gpu==1.13.0.dev20181210")
-RUN pip --no-cache-dir install tensorflow-gpu
+RUN pip --no-cache-dir install tensorflow-gpu==1.13.1
 ARG bazel_version=0.17.2
 # This is to install bazel, for development purposes.
 ENV BAZEL_VERSION ${bazel_version}


### PR DESCRIPTION
Right now the installation instructions for adversarial_asr [1] don't work, since the `tensorflow-gpu` version got updated to 1.14.0. Selecting the version 1.13.1 resolves the issue.

Here the output if version 1.13.1 ist **not** selected:
```
root@16632551e487:/tmp/lingvo# bazel build -c opt --config=cuda //lingvo:trainer
INFO: Analysed target //lingvo:trainer (0 packages loaded).
INFO: Found 1 target...
ERROR: missing input file '@tensorflow_solib//:tensorflow_solib/libtensorflow_framework.so'
ERROR: /root/.cache/bazel/_bazel_root/17eb95f0bc03547f4f1319e61997e114/external/tensorflow_solib/BUILD:2:1: @tensorflow_solib//:framework_lib: missing input file '@tensorflow_solib//:tensorflow_solib/libtensorflow_framework.so'
Target //lingvo:trainer failed to build
Use --verbose_failures to see the command lines of failed build steps.
ERROR: /root/.cache/bazel/_bazel_root/17eb95f0bc03547f4f1319e61997e114/external/tensorflow_solib/BUILD:2:1 1 input file(s) do not exist
INFO: Elapsed time: 0.208s, Critical Path: 0.01s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
```

[1] https://github.com/yaq007/cleverhans/tree/master/examples/adversarial_asr